### PR TITLE
Fixes game code reading for non-English

### DIFF
--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -142,7 +142,7 @@ export default class GameReader {
 				);
 				if (newGameCode) {
 					let split = newGameCode.split('\r\n');
-					if (split.length === 2 && split[0] === 'Code') {
+					if (split.length === 2) {
 						newGameCode = split[1];
 					} else {
 						newGameCode = '';


### PR DESCRIPTION
Allows for the game code to be read when using non-english among us.

Tested superficially (got into game and code updated and personal mic was detected on a local server) with Spanish, Korean, Russian (No issue with non latin scripts)

Note of caution, I'm not sure why you were checking for 
```
split[0] == 'Code' 
```
so I don't fully understand what this change will affect.
From what I can tell, I think you were just validating the read from memory?

I'm looking at using the memory read to set the "Menu" string so that it'd be "Sala" or the whatever localized string, but that'll be a separate pull request.