### PR TITLE
Updated dependency list to include Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Server code is located at [ottomated/CrewLink-server](https://github.com/ottomat
 ### Prerequisites
 
 This is an example of how to list things you need to use the software and how to install them.
+* [Python](https://www.python.org/downloads/)
 * [node.js](https://nodejs.org/en/download/)
 * yarn
 ```sh


### PR DESCRIPTION
This PR simply adds Python to the list of prerequisites in the readme file.

The dependency package memoryjs is built on top of node-gyp which requires python to be installed.  Without python installed, you can not run `yarn install`.

This is the error that the developer receives when they do not have python installed:

![image](https://user-images.githubusercontent.com/836241/100645421-41186100-3302-11eb-9537-871b445c835a.png)
