### PR TITLE
Allow CrewLink to connect over TLS to voice server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewlink",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "GPL-3.0-or-later",
   "description": "Free, open, Among Us proximity voice chat",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "publish": "yarn compile && electron-builder --win --x64 --publish always"
   },
   "dependencies": {
+    "ajv": "^6.12.6",
     "analyser-frequency-average": "^1.0.0",
     "audio-activity": "^1.0.0",
     "axios": "^0.21.0",

--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -70,16 +70,16 @@ async function loadOffsets(event: Electron.IpcMainEvent): Promise<IOffsets | und
 	} else {
 		try {
 			const response = await axios({
-				url: `${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml`
+				url: `${store.get('serverURL')}/${version}.yml`
 			});
 			data = response.data;
 		} catch (_e) {
 			let e = _e as AxiosError;
 			console.error(e);
 			if (e?.response?.status === 404) {
-				event.reply('error', `Couldn't fetch the latest game offsets from the server: ${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml.\nThis might be because you are on an unsupported version of Among Us.`);
+				event.reply('error', `Couldn't fetch the latest game offsets from the server: ${store.get('serverURL')}/${version}.yml.\nThis might be because you are on an unsupported version of Among Us.`);
 			} else {
-				event.reply('error', `Couldn't fetch the latest game offsets from the server: ${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml.\n${e}`);
+				event.reply('error', `Couldn't fetch the latest game offsets from the server: ${store.get('serverURL')}/${version}.yml.\n${e}`);
 			}
 			return;
 		}
@@ -100,7 +100,7 @@ async function loadOffsets(event: Electron.IpcMainEvent): Promise<IOffsets | und
 		return offsets;
 	} catch (e) {
 		console.error(e);
-		event.reply('error', `Couldn't parse the latest game offsets from the server: ${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml.\n${e}`);
+		event.reply('error', `Couldn't parse the latest game offsets from the server: ${store.get('serverURL')}/${version}.yml.\n${e}`);
 		return;
 	}
 

--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -70,16 +70,16 @@ async function loadOffsets(event: Electron.IpcMainEvent): Promise<IOffsets | und
 	} else {
 		try {
 			const response = await axios({
-				url: `http://${store.get('serverIP')}/${version}.yml`
+				url: `${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml`
 			});
 			data = response.data;
 		} catch (_e) {
 			let e = _e as AxiosError;
 			console.error(e);
 			if (e?.response?.status === 404) {
-				event.reply('error', `Couldn't fetch the latest game offsets from the server: http://${store.get('serverIP')}/${version}.yml.\nThis might be because you are on an unsupported version of Among Us.`);
+				event.reply('error', `Couldn't fetch the latest game offsets from the server: ${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml.\nThis might be because you are on an unsupported version of Among Us.`);
 			} else {
-				event.reply('error', `Couldn't fetch the latest game offsets from the server: http://${store.get('serverIP')}/${version}.yml.\n${e}`);
+				event.reply('error', `Couldn't fetch the latest game offsets from the server: ${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml.\n${e}`);
 			}
 			return;
 		}
@@ -100,7 +100,7 @@ async function loadOffsets(event: Electron.IpcMainEvent): Promise<IOffsets | und
 		return offsets;
 	} catch (e) {
 		console.error(e);
-		event.reply('error', `Couldn't parse the latest game offsets from the server: http://${store.get('serverIP')}/${version}.yml.\n${e}`);
+		event.reply('error', `Couldn't parse the latest game offsets from the server: ${store.get('secure') ? 'https' : 'http'}://${store.get('serverIP')}/${version}.yml.\n${e}`);
 		return;
 	}
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,7 +31,7 @@ function App() {
 		microphone: 'Default',
 		speaker: 'Default',
 		pushToTalk: false,
-		serverIP: '54.193.94.35:9736',
+		serverURL: 'http://54.193.94.35:9736',
 		pushToTalkShortcut: 'V',
 		deafenShortcut: 'RControl',
 		offsets: {
@@ -39,8 +39,7 @@ function App() {
 			data: ''
 		},
 		hideCode: false,
-		stereoInLobby: true,
-		secure: false
+		stereoInLobby: true
 	});
 
 	useEffect(() => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -39,7 +39,8 @@ function App() {
 			data: ''
 		},
 		hideCode: false,
-		stereoInLobby: true
+		stereoInLobby: true,
+		secure: false
 	});
 
 	useEffect(() => {

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -27,6 +27,10 @@ const store = new Store<ISettings>({
 			type: 'string',
 			default: '54.193.94.35:9736'
 		},
+		secure: {
+			type: 'boolean',
+			default: false
+		},
 		pushToTalkShortcut: {
 			type: 'string',
 			default: 'V'
@@ -78,6 +82,7 @@ export interface ISettings {
 	},
 	hideCode: boolean;
 	stereoInLobby: boolean;
+	secure: boolean;
 }
 export const settingsReducer = (state: ISettings, action: {
 	type: 'set' | 'setOne', action: [string, any] | ISettings
@@ -111,7 +116,7 @@ export default function Settings({ open, onClose }: SettingsProps) {
 
 	useEffect(() => {
 		setUnsavedCount(s => s + 1);
-	}, [settings.microphone, settings.speaker, settings.serverIP]);
+	}, [settings.microphone, settings.speaker, settings.serverIP, settings.secure]);
 
 	const [devices, setDevices] = useState<MediaDevice[]>([]);
 	const [_, updateDevices] = useReducer((state) => state + 1, 0);
@@ -240,6 +245,13 @@ export default function Settings({ open, onClose }: SettingsProps) {
 					type: 'setOne',
 					action: ['serverIP', ev.target.value]
 				})} value={settings.serverIP} />
+			</div>
+			<div className="form-control 1 m" style={{ color: '#3498db' }} onClick={() => setSettings({
+				type: 'setOne',
+				action: ['secure', !settings.secure]
+			})}>
+				<input type="checkbox" checked={settings.secure} style={{ color: '#3498db' }} readOnly />
+				<label>Secure Connection (TLS)</label>
 			</div>
 			<div className="form-control m" style={{ color: '#9b59b6' }} onClick={() => setSettings({
 				type: 'setOne',

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -6,7 +6,10 @@ import './css/settings.css';
 
 const keys = new Set(['Space', 'Backspace', 'Delete', 'Enter', 'Up', 'Down', 'Left', 'Right', 'Home', 'End', 'PageUp', 'PageDown', 'Escape', 'LControl', 'LShift', 'LAlt', 'RControl', 'RShift', 'RAlt']);
 
-const validateURL = new Ajv().compile({
+const validateURL = new Ajv({
+	allErrors: true,
+	format: 'full'
+}).compile({
 	type: 'string',
 	format: 'uri'
 });

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -148,7 +148,7 @@ export default function Voice() {
 	const connectionStuff = useRef<ConnectionStuff>({ pushToTalk: settings.pushToTalk, deafened: false } as any);
 	useEffect(() => {
 		// Connect to voice relay server
-		connectionStuff.current.socket = io(`${settings.secure ? 'wss' : 'ws'}://${settings.serverIP}`, { transports: ['websocket'] });
+		connectionStuff.current.socket = io(settings.serverURL, { transports: ['websocket'] });
 		const { socket } = connectionStuff.current;
 
 		socket.on('connect', () => {

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -148,7 +148,7 @@ export default function Voice() {
 	const connectionStuff = useRef<ConnectionStuff>({ pushToTalk: settings.pushToTalk, deafened: false } as any);
 	useEffect(() => {
 		// Connect to voice relay server
-		connectionStuff.current.socket = io(`ws://${settings.serverIP}`, { transports: ['websocket'] });
+		connectionStuff.current.socket = io(`${settings.secure ? 'wss' : 'ws'}://${settings.serverIP}`, { transports: ['websocket'] });
 		const { socket } = connectionStuff.current;
 
 		socket.on('connect', () => {

--- a/src/renderer/css/settings.css
+++ b/src/renderer/css/settings.css
@@ -46,6 +46,11 @@ input[type="text"] {
 	padding: 5px;
 	border-radius: 5px;
 }
+
+.form-control.m .input-error {
+	border-color: #b00020
+}
+
 input[type="text"]:focus {
 	border-color: white;
 }


### PR DESCRIPTION
I came across this issue when setting up a custom CrewLink server behind an nginx reverse proxy using TLS.

### What does this do?
This pull request introduces a toggle in the settings menu that allows CrewLink to connect to any voice server that is configured to handle TLS traffic. When checked, the protocol of all connection URLs will be changed from "ws://" and "http://" to "wss://" and "https://". The underlying libraries are already capable of handling HTTPs and WSs so this protocol change is all that is needed.

I've left the default as "off" for now as it would break the default voice server though I strongly recommend setting up a default voice server with TLS capabilities and making the secure option the default option.

### Why?
Among Us may be a silly game and most people would probably be OK with the fact that parties such as their local network admin, ISP and others between the client and server can listen to what they're talking about with others, but I think it should at least be an option to allow for an encrypted connection to the voice server.

On top of this, we're dealing with a program which **we trust** with **memory access to other programs**. While it may seem far-fetched, a malicious actor armed with an exploit could possibly abuse the offset files the program downloads over a plain text protocol and do way more harm than just listening in to what people are saying. Better be on the safe side and not have this be an attack vector.

I can provide a TLS capable server if needed for testing.