### PR TITLE
Replace hard-coded type strings with constant Enums for memoryjs

### DIFF
--- a/src/main/memoryjs.d.ts
+++ b/src/main/memoryjs.d.ts
@@ -33,10 +33,33 @@ declare module 'memoryjs' {
 	export function getProcesses(processId: number, callback?: Callback<ModuleObject[]>): ModuleObject[];
 
 	// Memory
-
 	export type Vector3 = { x: number, y: number, z: number };
 	export type Vector4 = { x: number, y: number, z: number, w: number };
-	export type DataType = "byte" | "int" | "int32" | "uint32" | "int64" | "uint64" | "dword" | "short" | "long" | "float" | "double" | "bool" | "boolean" | "ptr" | "pointer" | "str" | "string" | "vec3" | "vector3" | "vec4" | "vector4";
+
+	// Data type constants
+	export enum DataType {
+		BYTE = 'byte',
+		INT = 'int',
+		INT32 = 'int32',
+		UINT32 = 'uint32',
+		INT64 = 'int64',
+		UINT64 = 'uint64',
+		DWORD = 'dword',
+		SHORT = 'short',
+		LONG = 'long',
+		FLOAT = 'float',
+		DOUBLE = 'double',
+		BOOL = 'bool',
+		BOOLEAN = 'boolean',
+		PTR = 'ptr',
+		POINTER = 'pointer',
+		STR = 'str',
+		STRING = 'string',
+		VEC3 = 'vec3',
+		VECTOR3 = 'vector3',
+		VEC4 = 'vec4',
+		VECTOR4 = 'vector4',
+	}
 
 	export function readMemory<T>(handle: number, address: number, dataType: DataType, callback?: Callback<T>): T;
 


### PR DESCRIPTION
This PR makes no functional change, but replaces hard-coded strings with enums when specifying a data type to be read through the `memory.js` library.

Example: `'pointer'` -> `DataType.POINTER`

This both keeps the code (in my opinion) more reader-friendly, and more closely matches the intended usage of `memory.js`.

The `DataType` enum is defined in `memoryjs.d.ts`, and is a typed copy of the constants [defined here](https://github.com/Rob--/memoryjs/blob/79618efdefc2aac203ae7137eefa2cf30cf888ce/index.js#L6-L26).

I also switched all references to the `ptr` datatype to `pointer`, since [they are functionally the same](https://github.com/Rob--/memoryjs/blob/bfde6ca9ac9c408bd25826a66429e84b94552d12/lib/memoryjs.cc#L383)