### PR TITLE
Remove README template text from prerequisite list

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Server code is located at [ottomated/CrewLink-server](https://github.com/ottomat
 
 ### Prerequisites
 
-This is an example of how to list things you need to use the software and how to install them.
 * [Python](https://www.python.org/downloads/)
 * [node.js](https://nodejs.org/en/download/)
 * yarn


### PR DESCRIPTION
This PR just removes a line of text under the 'Prerequisites' header that is leftover from the initial README template.