### PR TITLE
Changed regex to include device name

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -189,9 +189,9 @@ export default function Settings({ open, onClose }: SettingsProps) {
 					if (d.deviceId === 'default') {
 						label = "Default";
 					} else {
-						let match = /\((.+?)\)/.exec(d.label);
+						let match = /(.+?)\)/.exec(d.label);
 						if (match && match[1])
-							label = match[1];
+							label = match[1] + ")";
 					}
 					return {
 						id: d.deviceId,


### PR DESCRIPTION
Many devices had the same name, or were generic. This alters the regex to include all text before the first close bracket. Then it adds the close bracket to the string so that the names include the device name.