### PR TITLE
Add Issue templates and config to help reduce spam

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+---
+
+# Pre-Flight Checklist
+Please use this checklist to avoid spamming:
+
+1. [ ] I am not asking a question => goto the Discord if you are [discord](https://discord.gg/9mwuVNA)
+2. [ ] I am using the Steam version of Among Us
+3. [ ] I have tried to use an [alternative server](https://status.crewl.ink/)
+4. [ ] I have checked everyone in my lobby is on the same CrewLink server
+5. [ ] I have used `Ctrl+r` on the CrewLink app when I can't hear some people (this is a known issue)
+6. [ ] I have checked the CrewLink server I'm using is up to date
+7. [ ] I have a screenshot of any errors
+8. [ ] I checked someone else has not reported this. Meaning the devs don't have to deal with duplicates and have more time to add cool stuff
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behaviour**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version: [e.g. 22]
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: I need help?
+    url:  https://discord.gg/9mwuVNA
+    about: Please ask and answer questions here.
+  - name: Security issue
+    url: https://discord.gg/9mwuVNA
+    about: Please report security vulnerabilities directly to Ottomated#9999.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
Currently there is a lot of "low hanging" spam of issues, where some users are just asking support questions. Hopefully these changes will nudge them towards a better support channel.