### PR TITLE
Set minimum window width and height

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,8 @@ if (!gotTheLock) {
 		const window = new BrowserWindow({
 			width: 250,
 			height: 350,
+			minWidth: 250,
+			minHeight: 350,
 			resizable: false,
 			frame: false,
 			fullscreenable: false,


### PR DESCRIPTION
Sets the minimum size to 250x350 (default window size).

This is to prevent the window to appear as such:

![small width](https://user-images.githubusercontent.com/7542961/101834510-c1c53180-3b3a-11eb-9da8-d4d92c00ecaf.png) ![small height](https://user-images.githubusercontent.com/7542961/101834494-be31aa80-3b3a-11eb-9ab7-9ba6caec2317.png)
