### PR TITLE
Communications sabotage mutes everyone until fixed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Please use this checklist to avoid spamming:
 
 1. [ ] I am not asking a question => use the [Discord](https://discord.gg/9mwuVNA) if you are
 2. [ ] I am using the Steam version of Among Us
-3. [ ] I have tried to use an [alternative voice server server](https://status.crewl.ink/)
+3. [ ] I have tried to use an [alternative voice server](https://status.crewl.ink/)
 4. [ ] I have checked everyone in my lobby is on the same CrewLink server
 5. [ ] I have used `Ctrl+R` on the CrewLink app when I can't hear some people (this is a known issue)
 6. [ ] I have checked that the CrewLink server I'm using is up to date

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -41,7 +41,9 @@ const store = new Store<ISettings>({
 		},
 		'1.1.6': store => {
 			const enableSpatialAudio = store.get('stereoInLobby');
-			store.set('enableSpatialAudio', enableSpatialAudio);
+			if (typeof enableSpatialAudio === 'boolean') {
+				store.set('enableSpatialAudio', enableSpatialAudio);
+			}
 			// @ts-ignore
 			store.delete('stereoInLobby');
 		}


### PR DESCRIPTION
Communications sabotage mutes everyone until sabotage fixed. It'll make the sabotage useful finally and it'll be a cool concept to add to the crewlink. 