### PR TITLE
Force window size

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,10 @@ function createMainWindow() {
 	const window = new BrowserWindow({
 		width: 250,
 		height: 350,
+		maxWidth: 250,
+		minWidth: 250,
+		maxHeight: 350,
+		minHeight: 350,
 		x: mainWindowState.x,
 		y: mainWindowState.y,
 


### PR DESCRIPTION
Similar to #301, but as a more appropriate PR title.

Enforces the window cannot be any other size than 250x350. It is still possible to manipulate the Window size with special tools using Windows API calls to set the size.

![small width](https://user-images.githubusercontent.com/7542961/101834510-c1c53180-3b3a-11eb-9da8-d4d92c00ecaf.png) ![small height](https://user-images.githubusercontent.com/7542961/101834494-be31aa80-3b3a-11eb-9ab7-9ba6caec2317.png)