### PR TITLE
Add Server URL to main screen for subtle visual cue

### DIFF
--- a/src/common/ISettings.d.ts
+++ b/src/common/ISettings.d.ts
@@ -12,5 +12,6 @@ export interface ISettings {
 		data: string;
 	},
 	hideCode: boolean;
+	hideVoiceServer: boolean;
 	enableSpatialAudio: boolean;
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,13 +17,16 @@ app.commandLine.appendSwitch('disable-pinch');
 function createMainWindow() {
 	const mainWindowState = windowStateKeeper({});
 
+	const height = 370
+	const width = 250
+
 	const window = new BrowserWindow({
-		width: 250,
-		height: 350,
-		maxWidth: 250,
-		minWidth: 250,
-		maxHeight: 350,
-		minHeight: 350,
+		width: width,
+		height: height,
+		maxWidth: width,
+		minWidth: width,
+		maxHeight: height,
+		minHeight: height,
 		x: mainWindowState.x,
 		y: mainWindowState.y,
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,11 +22,11 @@ function createMainWindow() {
 
 	const window = new BrowserWindow({
 		width: width,
-		height: height,
-		maxWidth: width,
 		minWidth: width,
-		maxHeight: height,
+		maxWidth: width,
+		height: height,
 		minHeight: height,
+		maxHeight: height,
 		x: mainWindowState.x,
 		y: mainWindowState.y,
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -34,6 +34,7 @@ function App() {
 			data: ''
 		},
 		hideCode: false,
+		hideVoiceServer: false,
 		enableSpatialAudio: true
 	});
 

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -95,6 +95,10 @@ const store = new Store<ISettings>({
 			type: 'boolean',
 			default: false
 		},
+		hideVoiceServer: {
+			type: 'boolean',
+			default: false
+		},
 		enableSpatialAudio: {
 			type: 'boolean',
 			default: true
@@ -304,6 +308,13 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 				<input type="checkbox" checked={!settings.hideCode} style={{ color: '#9b59b6' }} readOnly />
 				<label>Show Lobby Code</label>
 			</div>
+			<div className="form-control m" style={{ color: '#9b59b6' }} onClick={() => setSettings({
+				type: 'setOne',
+				action: ['hideVoiceServer', !settings.hideVoiceServer]
+			})}>
+				<input type="checkbox" checked={!settings.hideVoiceServer} style={{ color: '#9b59b6' }} readOnly />
+				<label>Show Voice Server</label>
+			</div>
 			<div className="form-control m" style={{ color: '#fd79a8' }} onClick={() => setSettings({
 				type: 'setOne',
 				action: ['enableSpatialAudio', !settings.enableSpatialAudio]
@@ -313,7 +324,7 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 			</div>
 			<div className='settings-alert' style={{ display: unsaved ? 'flex' : 'none' }}>
 				<span>
-					Exit to apply changes
+					Close Settings to apply changes
 				</span>
 			</div>
 		</div>

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -414,7 +414,6 @@ const Voice: React.FC = function () {
 				}
 			</div>
 			<div className="footer">
-				<hr />
 				{displayedVoiceServer}
 			</div>
 		</div>

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -94,6 +94,8 @@ const Voice: React.FC = function () {
 	const gameState = useContext(GameStateContext);
 	let { lobbyCode: displayedLobbyCode } = gameState;
 	if (displayedLobbyCode !== 'MENU' && settings.hideCode) displayedLobbyCode = 'LOBBY';
+	let displayedVoiceServer = settings.serverURL;
+	if (settings.hideVoiceServer) displayedVoiceServer = '';
 	const [talking, setTalking] = useState(false);
 	const [socketPlayerIds, setSocketPlayerIds] = useState<SocketIdMap>({});
 	const [connect, setConnect] = useState<({ connect: (lobbyCode: string, playerId: number) => void }) | null>(null);
@@ -410,6 +412,10 @@ const Voice: React.FC = function () {
 						);
 					})
 				}
+			</div>
+			<div className="footer">
+				<hr />
+				{displayedVoiceServer}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Upon using CrewLink in public Among Us discord servers, newbies to the app generally get confused when trying to figure out what/how to join the correct Voice Server. This change is simple, and adds a bit of a subtle visual cue on the main screen for those who don't understand what's going on. 

The desired outcome for this PR is that those who are new to the app will see `https://crewl.ink` and then know they need to check Settings to update it.

![image](https://user-images.githubusercontent.com/8714307/102001615-b77d7180-3cb9-11eb-8ae7-7db43afd102a.png) ![image](https://user-images.githubusercontent.com/8714307/102001604-94eb5880-3cb9-11eb-8345-b665528e254e.png) ![image](https://user-images.githubusercontent.com/8714307/102001609-a2a0de00-3cb9-11eb-949c-13ab9c0a5d32.png) ![image](https://user-images.githubusercontent.com/8714307/102003310-2f07cc80-3ccb-11eb-98a2-69afbe4abf4a.png)


There is a toggle to hide it, so it doesn't show anything if desired from the Settings page (good for streamers).

