### PR TITLE
Add basic version event to check server version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ajv": "^6.12.6",
     "analyser-frequency-average": "^1.0.0",
     "axios": "^0.21.0",
+    "compare-versions": "^3.6.0",
     "cross-spawn": "^7.0.3",
     "electron-store": "^6.0.1",
     "electron-updater": "^4.3.5",

--- a/src/common/Version.ts
+++ b/src/common/Version.ts
@@ -1,0 +1,10 @@
+let version = '';
+
+if (typeof window !== 'undefined' && window.location) {
+    const query = new URLSearchParams(window.location.search.substring(1));
+    version = query.get('version') || '';
+}
+
+export const appVersion = version
+
+export const isDevelopment = process.env.NODE_ENV !== 'production'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,9 +5,8 @@ import { app, BrowserWindow } from 'electron';
 import windowStateKeeper from 'electron-window-state';
 import { join as joinPath } from 'path';
 import { format as formatUrl } from 'url';
+import { isDevelopment } from '../common/Version';
 import './hook';
-
-const isDevelopment = process.env.NODE_ENV !== 'production';
 
 // global reference to mainWindow (necessary to prevent window from being garbage collected)
 let mainWindow: BrowserWindow | null;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,11 +6,11 @@ import { ipcRenderer, remote } from 'electron';
 import { AmongUsState } from '../common/AmongUsState';
 import Settings, { settingsReducer } from './Settings';
 import { GameStateContext, SettingsContext } from './contexts';
+import { appVersion } from '../common/Version';
 
-let appVersion = '';
-if (typeof window !== 'undefined' && window.location) {
-	const query = new URLSearchParams(window.location.search.substring(1));
-	appVersion = (' v' + query.get('version')) || '';
+let appVersionStr = '';
+if (appVersion != '') {
+	appVersionStr = ' v' + appVersion;
 }
 
 
@@ -78,7 +78,7 @@ function App() {
 		<GameStateContext.Provider value={gameState}>
 			<SettingsContext.Provider value={settings}>
 				<div className="titlebar">
-					<span className="title">CrewLink{appVersion}</span>
+					<span className="title">CrewLink{appVersionStr}</span>
 					<svg className="titlebar-button settings" onClick={() => setSettingsOpen(!settingsOpen)} enableBackground="new 0 0 24 24" viewBox="0 0 24 24" fill="#868686" width="20px" height="20px">
 						<g>
 							<path d="M0,0h24v24H0V0z" fill="none" />

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -8,6 +8,7 @@ import Peer from 'simple-peer';
 import { ipcRenderer, remote } from 'electron';
 import VAD from './vad';
 import { ISettings } from '../common/ISettings';
+import { appVersion, isDevelopment} from '../common/Version';
 
 export interface ExtendedAudioElement extends HTMLAudioElement {
 	setSinkId: (sinkId: string) => Promise<void>;
@@ -86,14 +87,6 @@ function calculateVoiceAudio(state: AmongUsState, settings: ISettings, me: Playe
 	if (gain.gain.value === 1 && Math.sqrt(Math.pow(panPos[0], 2) + Math.pow(panPos[1], 2)) > 7) {
 		gain.gain.value = 0;
 	}
-}
-
-let appVersion = '';
-const isDevelopment = process.env.NODE_ENV !== 'production';
-
-if (typeof window !== 'undefined' && window.location) {
-	const query = new URLSearchParams(window.location.search.substring(1));
-	appVersion = query.get('version')|| '';
 }
 
 const Voice: React.FC = function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,11 +1844,6 @@ atomically@^1.3.1:
   resolved "https://registry.yarnpkg.com/atomically/-/atomically-1.6.0.tgz#d8d47f99834dbb88bd6266cc69a1447e2f3675ec"
   integrity sha512-mu394MH+yY2TSKMyH+978PcGMZ8sRNks2PuVeH6c2ED4mimR2LEE039MVcIGVhtmG54cKEMh4gKhxKL/CLaX/w==
 
-audio-activity@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/audio-activity/-/audio-activity-1.0.0.tgz#f653b9668582e7fd6a4c9b9997abe26607bcc456"
-  integrity sha1-9lO5ZoWC5/1qTJuZl6viZge8xFY=
-
 audio-frequency-to-index@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/audio-frequency-to-index/-/audio-frequency-to-index-2.0.0.tgz#4c4bca9f3bfec38c773aa6b5604c117adc982d45"
@@ -2635,6 +2630,11 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
 component-bind@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR will add a "version" event that servers can emit, which will help prevent out of date server versions with clients and notify users when features aren't available.

This event won't be fired with existing servers, and won't cause any impact if not implemented.

See https://github.com/ottomated/CrewLink-server/pull/71 for the server PR.

Note: If #352 is merged first, I'll clean this up to use that for messages.