### PR TITLE
Trim Server URL

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -145,11 +145,13 @@ function URLInput({ initialURL, onValidURL }: URLInputProps) {
 	}, [initialURL]);
 
 	function onChange(event: React.ChangeEvent<HTMLInputElement>) {
-		setCurrentURL(event.target.value);
+		var eventValue = event.target.value.trim();
 
-		if (validateURL(event.target.value)) {
+		setCurrentURL(eventValue);
+
+		if (validateURL(eventValue)) {
 			setURLValid(true);
-			onValidURL(event.target.value);
+			onValidURL(eventValue);
 		} else {
 			setURLValid(false);
 		}


### PR DESCRIPTION
Whenever a Server URL is copy/pasted, it sometimes adds a space if the user accidentally adds it. This trims the beginning and end.