### PR TITLE
Add Mouse Button 4/5/6/7 Push To Talk

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,7 @@ rules:
     - tab
   linebreak-style:
     - error
-    - unix
+    - windows
   quotes:
     - error
     - single

--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -118,7 +118,7 @@ ipcMain.on('start', async (event) => {
 			if (!isMouseButton(shortcutKey) && keyCodeMatches(shortcutKey as K, ev)) {
 				event.reply('pushToTalk', false);
 			}
-			if (!isMouseButton(shortcutKey) && keyCodeMatches(store.get('deafenShortcut') as K, ev)) {
+			if (!isMouseButton(store.get('deafenShortcut')) && keyCodeMatches(store.get('deafenShortcut') as K, ev)) {
 				event.reply('toggleDeafen');
 			}
 		});

--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -190,7 +190,7 @@ const mouseClickMap = {
 	'MouseButton5': 5,
 	'MouseButton6': 6,
 	'MouseButton7': 7
-}
+};
 
 type M = keyof typeof mouseClickMap;
 
@@ -201,7 +201,7 @@ function mouseClickMatches(key: M, ev: IOHookEvent): boolean {
 }
 
 function isMouseButton(shortcutKey:string): boolean {
-	return !!shortcutKey.match("MouseButton");
+	return !!shortcutKey.match('MouseButton');
 }
 
 ipcMain.on('openGame', () => {

--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -109,17 +109,31 @@ ipcMain.on('start', async (event) => {
 		// Register key events
 		iohook.on('keydown', (ev: IOHookEvent) => {
 			const shortcutKey = store.get('pushToTalkShortcut');
-			if (keyCodeMatches(shortcutKey as K, ev)) {
+			if (!isMouseButton(shortcutKey) && keyCodeMatches(shortcutKey as K, ev)) {
 				event.reply('pushToTalk', true);
 			}
 		});
 		iohook.on('keyup', (ev: IOHookEvent) => {
 			const shortcutKey = store.get('pushToTalkShortcut');
-			if (keyCodeMatches(shortcutKey as K, ev)) {
+			if (!isMouseButton(shortcutKey) && keyCodeMatches(shortcutKey as K, ev)) {
 				event.reply('pushToTalk', false);
 			}
-			if (keyCodeMatches(store.get('deafenShortcut') as K, ev)) {
+			if (!isMouseButton(shortcutKey) && keyCodeMatches(store.get('deafenShortcut') as K, ev)) {
 				event.reply('toggleDeafen');
+			}
+		});
+
+		// Register mouse events
+		iohook.on('mousedown', (ev: IOHookEvent) => {
+			const shortcutMouse = store.get('pushToTalkShortcut');
+			if (isMouseButton(shortcutMouse) && mouseClickMatches(shortcutMouse as M, ev)) {
+				event.reply('pushToTalk', true);
+			}
+		});
+		iohook.on('mouseup', (ev: IOHookEvent) => {
+			const shortcutMouse = store.get('pushToTalkShortcut');
+			if (isMouseButton(shortcutMouse) && mouseClickMatches(shortcutMouse as M, ev)) {
+				event.reply('pushToTalk', false);
 			}
 		});
 
@@ -160,6 +174,7 @@ const keycodeMap = {
 type K = keyof typeof keycodeMap;
 
 function keyCodeMatches(key: K, ev: IOHookEvent): boolean {
+
 	if (keycodeMap[key])
 		return keycodeMap[key] === ev.keycode;
 	else if (key.length === 1)
@@ -170,7 +185,24 @@ function keyCodeMatches(key: K, ev: IOHookEvent): boolean {
 	}
 }
 
+const mouseClickMap = {
+	'MouseButton4': 4,
+	'MouseButton5': 5,
+	'MouseButton6': 6,
+	'MouseButton7': 7
+}
 
+type M = keyof typeof mouseClickMap;
+
+function mouseClickMatches(key: M, ev: IOHookEvent): boolean {
+	if (mouseClickMap[key])
+		return mouseClickMap[key] === ev.button;
+	return false;
+}
+
+function isMouseButton(shortcutKey:string): boolean {
+	return !!shortcutKey.match("MouseButton");
+}
 
 ipcMain.on('openGame', () => {
 	// Get steam path from registry

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -197,6 +197,7 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 	}, [_]);
 
 	const setShortcut = (ev: React.KeyboardEvent<HTMLInputElement>, shortcut: string) => {
+
 		let k = ev.key;
 		if (k.length === 1) k = k.toUpperCase();
 		else if (k.startsWith('Arrow')) k = k.substring(5);
@@ -208,6 +209,18 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 		if (/^[0-9A-Z]$/.test(k) || /^F[0-9]{1,2}$/.test(k) ||
 			keys.has(k)
 		) {
+			setSettings({
+				type: 'setOne',
+				action: [shortcut, k]
+			});
+		}
+	};
+
+	const setMouseShortcut = (ev: React.MouseEvent<HTMLInputElement>, shortcut: string) => {
+		if(ev.button > 2){
+			// this makes our button start at 1 instead of 0
+			// React Mouse event starts at 0, but IOHooks starts at 1
+			let k = `MouseButton${ev.button+1}`;
 			setSettings({
 				type: 'setOne',
 				action: [shortcut, k]
@@ -281,7 +294,9 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 			</div>
 			{settings.pushToTalk &&
 				<div className="form-control m" style={{ color: '#f1c40f' }}>
-					<input spellCheck={false} type="text" value={settings.pushToTalkShortcut} readOnly onKeyDown={(ev) => setShortcut(ev, 'pushToTalkShortcut')} />
+					<input spellCheck={false} type="text" value={settings.pushToTalkShortcut} readOnly 
+					onMouseDown={(ev)=> setMouseShortcut(ev, 'pushToTalkShortcut')} 
+					onKeyDown={(ev) => setShortcut(ev, 'pushToTalkShortcut')} />
 				</div>
 			}
 			<div className="form-control l m" style={{ color: '#2ecc71' }}>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -220,7 +220,7 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 		if(ev.button > 2){
 			// this makes our button start at 1 instead of 0
 			// React Mouse event starts at 0, but IOHooks starts at 1
-			let k = `MouseButton${ev.button+1}`;
+			const k = `MouseButton${ev.button+1}`;
 			setSettings({
 				type: 'setOne',
 				action: [shortcut, k]
@@ -295,8 +295,8 @@ const Settings: React.FC<SettingsProps> = function ({ open, onClose }: SettingsP
 			{settings.pushToTalk &&
 				<div className="form-control m" style={{ color: '#f1c40f' }}>
 					<input spellCheck={false} type="text" value={settings.pushToTalkShortcut} readOnly 
-					onMouseDown={(ev)=> setMouseShortcut(ev, 'pushToTalkShortcut')} 
-					onKeyDown={(ev) => setShortcut(ev, 'pushToTalkShortcut')} />
+						onMouseDown={(ev)=> setMouseShortcut(ev, 'pushToTalkShortcut')} 
+						onKeyDown={(ev) => setShortcut(ev, 'pushToTalkShortcut')} />
 				</div>
 			}
 			<div className="form-control l m" style={{ color: '#2ecc71' }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,11 +1844,6 @@ atomically@^1.3.1:
   resolved "https://registry.yarnpkg.com/atomically/-/atomically-1.6.0.tgz#d8d47f99834dbb88bd6266cc69a1447e2f3675ec"
   integrity sha512-mu394MH+yY2TSKMyH+978PcGMZ8sRNks2PuVeH6c2ED4mimR2LEE039MVcIGVhtmG54cKEMh4gKhxKL/CLaX/w==
 
-audio-activity@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/audio-activity/-/audio-activity-1.0.0.tgz#f653b9668582e7fd6a4c9b9997abe26607bcc456"
-  integrity sha1-9lO5ZoWC5/1qTJuZl6viZge8xFY=
-
 audio-frequency-to-index@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/audio-frequency-to-index/-/audio-frequency-to-index-2.0.0.tgz#4c4bca9f3bfec38c773aa6b5604c117adc982d45"


### PR DESCRIPTION
**Description**
This adds mouse push to talk, for mouse button 4/5/6/7. (Any button that is not left click, right click and middle click)

**Motivation**
This is as suggested by https://github.com/ottomated/CrewLink/issues/346 and https://github.com/ottomated/CrewLink/issues/34

**Testing**
- [x] Push to talk with keys still works
- [x] Push to talk with mouse button 4/5/6/7 works

![image](https://user-images.githubusercontent.com/5773562/102177846-4d461600-3edf-11eb-830b-9db6e9e46639.png)
