### PR TITLE
WIP support for GamePass/Xbox/WindowsStore edition of Among Us

### DIFF
--- a/src/main/baked-offsets.ts
+++ b/src/main/baked-offsets.ts
@@ -1,0 +1,107 @@
+export const offset_2020_12_5 = `
+meetingHud: [0x1BE0CB4, 0x5c, 0]
+meetingHudCachePtr: [0x8]
+meetingHudState: [0x84]
+gameState: [0x1BE1074, 0x5C, 0, 0x64]
+
+allPlayersPtr: [0x1BE0BB8, 0x5c, 0, 0x24]
+allPlayers: [0x08]
+playerCount: [0x0c]
+playerAddrPtr: 0x10
+exiledPlayerId: [0xff, 0x1BE0CB4, 0x5c, 0, 0x94, 0x08]
+
+gameCode: [0x1B5AB00, 0x5c, 0, 0x20, 0x28]
+
+player:
+  struct:
+  - type: SKIP
+    skip: 8
+    name: unused
+  - type: UINT
+    name: id
+  - type: UINT
+    name: name
+  - type: UINT
+    name: color
+  - type: UINT
+    name: hat
+  - type: UINT
+    name: pet
+  - type: UINT
+    name: skin
+  - type: UINT
+    name: disconnected
+  - type: UINT
+    name: taskPtr
+  - type: BYTE
+    name: impostor
+  - type: BYTE
+    name: dead
+  - type: SKIP
+    skip: 2
+    name: unused
+  - type: UINT
+    name: objectPtr
+  isLocal: [0x54]
+  localX: [0x60, 0x50]
+  localY: [0x60, 0x54]
+  remoteX: [0x60, 0x3C]
+  remoteY: [0x60, 0x40]
+  bufferLength: 56
+  offsets: [0, 0]
+  inVent: [0x31]
+`
+export const offsets_2020_12_9 = `
+meetingHud: [0x1C573A4, 0x5c, 0]
+meetingHudCachePtr: [0x8]
+meetingHudState: [0x84]
+gameState: [0x1C57F54, 0x5C, 0, 0x64]
+
+allPlayersPtr: [0x1C57BE8, 0x5c, 0, 0x24]
+allPlayers: [0x08]
+playerCount: [0x0c]
+playerAddrPtr: 0x10
+exiledPlayerId: [0xff, 0x1C573A4, 0x5c, 0, 0x94, 0x08]
+
+gameCode: [0x1AF20FC, 0x5c, 0, 0x20, 0x28]
+
+player:
+  struct:
+  - type: SKIP
+    skip: 8
+    name: unused
+  - type: UINT
+    name: id
+  - type: UINT
+    name: name
+  - type: UINT
+    name: color
+  - type: UINT
+    name: hat
+  - type: UINT
+    name: pet
+  - type: UINT
+    name: skin
+  - type: UINT
+    name: disconnected
+  - type: UINT
+    name: taskPtr
+  - type: BYTE
+    name: impostor
+  - type: BYTE
+    name: dead
+  - type: SKIP
+    skip: 2
+    name: unused
+  - type: UINT
+    name: objectPtr
+  isLocal: [0x54]
+  localX: [0x60, 0x50]
+  localY: [0x60, 0x54]
+  remoteX: [0x60, 0x3C]
+  remoteY: [0x60, 0x40]
+  bufferLength: 56
+  offsets: [0, 0]
+  inVent: [0x31]
+
+`

--- a/src/main/hook.ts
+++ b/src/main/hook.ts
@@ -14,20 +14,22 @@ import { createCheckers } from 'ts-interface-checker';
 import TI from './hook-ti';
 import { existsSync, readFileSync } from 'fs';
 import { IOffsets } from './IOffsets';
+import { offsets_2020_12_9 } from './baked-offsets';
 const { IOffsets } = createCheckers(TI);
 
 interface IOHookEvent {
-  type: string
-  keychar?: number
-  keycode?: number
-  rawcode?: number
-  button?: number
-  clicks?: number
-  x?: number
-  y?: number
+	type: string
+	keychar?: number
+	keycode?: number
+	rawcode?: number
+	button?: number
+	clicks?: number
+	x?: number
+	y?: number
 }
 
 const store = new Store<ISettings>();
+let edition: 'steam' | 'windowsstore' = 'steam';
 
 async function loadOffsets(event: Electron.IpcMainEvent): Promise<IOffsets | undefined> {
 
@@ -43,11 +45,37 @@ async function loadOffsets(event: Electron.IpcMainEvent): Promise<IOffsets | und
 			return;
 		}
 	} else {
-		event.reply('error', 'Couldn\'t determine the Among Us version - Unity analytics file doesn\'t exist. Try opening Among Us and then restarting CrewLink.');
-		return;
+		// Try to get Windows Store install location via Windows Powershell cmdlet
+		const process = spawn.sync('powershell.exe', [
+			'-nologo',
+			'-executionpolicy', 'remotesigned',
+			'-noprofile',
+			'-command', 'Get-AppxPackage -Name InnerSloth.AmongUs | ConvertTo-Json'
+		], {
+			stdio: ['ignore', 'pipe', 'ignore'],
+			encoding: 'utf8'
+		});
+		if (process.status === 0) {
+			try {
+				const appxManifest = JSON.parse(process.output[1]);
+				version = appxManifest.Version;
+				edition = 'windowsstore';
+			} catch (e) {
+				console.error(e);
+				event.reply('error', `Couldn't determine the Among Us version - ${e}. Try opening Among Us and then restarting CrewLink.`);
+				return;
+			}
+		} else {
+			event.reply('error', 'Couldn\'t determine the Among Us version - Unity analytics file or Windows Store installation doesn\'t exist. Try opening Among Us and then restarting CrewLink.');
+		}
 	}
 
 	let data: string;
+	store.set('offsets', {
+		version: '2020.12.4.0',
+		data: offsets_2020_12_9
+	});
+
 	const offsetStore = store.get('offsets') || {};
 	if (version === offsetStore.version) {
 		data = offsetStore.data;
@@ -173,6 +201,9 @@ function keyCodeMatches(key: K, ev: IOHookEvent): boolean {
 
 
 ipcMain.on('openGame', () => {
+	if(edition === 'windowsstore') {
+		dialog.showErrorBox('Error', 'CrewLink thinks you are using the Windows Store / XBox edition of Among Us.  You must launch Among Us manually.');
+	}
 	// Get steam path from registry
 	const steamPath = enumerateValues(HKEY.HKEY_LOCAL_MACHINE,
 		'SOFTWARE\\WOW6432Node\\Valve\\Steam')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,16 +18,16 @@ function createMainWindow() {
 	const mainWindowState = windowStateKeeper({});
 
 	const window = new BrowserWindow({
-		width: 250,
-		height: 350,
-		maxWidth: 250,
-		minWidth: 250,
-		maxHeight: 350,
-		minHeight: 350,
+		width: 1000,
+		height: 1000,
+		// maxWidth: 1000,
+		// minWidth: 1000,
+		// maxHeight: 1000,
+		// minHeight: 1000,
 		x: mainWindowState.x,
 		y: mainWindowState.y,
 
-		resizable: false,
+		// resizable: false,
 		frame: false,
 		fullscreenable: false,
 		maximizable: false,


### PR DESCRIPTION
I've started working on support for the Windows Store version of Among Us, to fix #411.

I'm able to use a powershell.exe invocation to get a version number: `2020.12.4.0`.  This version number looks different than the Steam release.  Partly I think this is because Windows appx manifests must have a version number with 4 parts, hence the trailing `.0`.  But also it appears that the 2x newest offsets files are not correct for this binary, so offsets will need to be recomputed.

To make things easier for myself, I've increased the window size and hardcoded the offsets data rather than fetching it from `crewl.ink`.  I'll need to remove those changes from the PR before it can be merged.