### PR TITLE
electron store localLobby Settings schema fix

### DIFF
--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -200,6 +200,7 @@ const store = new Store<ISettings>({
 					default: 5.32,
 				},
 			},
+			default:{},
 		},
 	},
 });


### PR DESCRIPTION
I know this is a small fix but I did spend some time to figure out the root cause of this issue.
I pulled this project in yesterday and couldn't start the application due to this error:
![image](https://user-images.githubusercontent.com/58826775/103162849-d0127f00-47c3-11eb-8bf0-8e0b98ee46a7.png)

After some time debugging I realized you probably aware of this issue since you console.loged in line 344 of the Settings file.
I checked the electron-store library as well as avj and found out that you need to have a default object for an object to work otherwise it will not be recognized in the store.

Here is a link to the issue as well in electron-store:
https://github.com/sindresorhus/electron-store/issues/102