### PR TITLE
Fix 1.2 related issues

### DIFF
--- a/src/main/GameReader.ts
+++ b/src/main/GameReader.ts
@@ -202,7 +202,8 @@ export default class GameReader {
 					this.PlayerStruct
 				);
 				playerAddrPtr += 4;
-				players.push(player);
+				if (state !== GameState.MENU)
+					players.push(player);
 
 				if (
 					player.name === '' ||

--- a/src/renderer/Avatar.tsx
+++ b/src/renderer/Avatar.tsx
@@ -141,6 +141,7 @@ const useCanvasStyles = makeStyles(() => ({
 		position: 'absolute',
 		top: '38%',
 		left: '17%',
+		width: '73.5%',
 		transform: 'scale(0.8)',
 		zIndex: 3,
 		display: ({ isAlive }: UseCanvasStylesParams) =>

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -655,7 +655,7 @@ const Voice: React.FC<VoiceProps> = function ({
 	} = {};
 
 	for (const k of Object.keys(socketClients)) {
-		if (socketClients[k].playerId)
+		if (socketClients[k].playerId !== undefined)
 			playerSocketIds[socketClients[k].playerId] = k;
 	}
 	return (

--- a/src/renderer/Voice.tsx
+++ b/src/renderer/Voice.tsx
@@ -390,7 +390,6 @@ const Voice: React.FC<VoiceProps> = function ({
 					clientId: number
 				) => {
 					console.log('Connect called', lobbyCode, playerId, clientId);
-					socket.emit('leave');
 					if (lobbyCode === 'MENU') {
 						Object.keys(peerConnections).forEach((k) => {
 							disconnectPeer(k);
@@ -476,7 +475,7 @@ const Voice: React.FC<VoiceProps> = function ({
 						});
 					});
 					connection.on('data', (data) => {
-						if (gameState.hostId !== socketClientsRef.current[peer].clientId)
+						if (gameState.hostId !== socketClientsRef.current[peer]?.clientId)
 							return;
 						const settings = JSON.parse(data);
 						Object.keys(lobbySettings).forEach((field: string) => {

--- a/src/renderer/settings/Settings.tsx
+++ b/src/renderer/settings/Settings.tsx
@@ -472,7 +472,7 @@ const Settings: React.FC<SettingsProps> = function ({
 		if (k === 'Control' || k === 'Alt' || k === 'Shift')
 			k = (ev.location === 1 ? 'L' : 'R') + k;
 
-		if (/^[0-9A-Z]$/.test(k) || /^F[0-9]{1, 2}$/.test(k) || keys.has(k)) {
+		if (/^[0-9A-Z]$/.test(k) || /^F[0-9]{1,2}$/.test(k) || keys.has(k)) {
 			setSettings({
 				type: 'setOne',
 				action: [shortcut, k],


### PR DESCRIPTION
Hey,

I came accross some bugs on the new 1.2 version.

1. NoVoice icon for the host player
   - the voice peer seems to work nevertheless
2. fix skin size on crewmates
3. fix issue when the host created or left a lobby before creating the current one
   - workaround: The host should refresh the crewlink client (ctrl + r). After that, all players with the black client can refresh too.
   - seems to be related to #462
4. fix F-key shortcut

I have only been able to test the whole thing with two players so far.

The code changes in GameReader.ts are necessary so that the client gets a new gamestate.players list when leaving the lobby, which triggers the `connectionStuff.current.socket.emit('id', ...)`. I haven't found a better way to trigger the emit.

So to reproduce the 3. issue, you need at least two players. The host creates a lobby -> leaves the lobby -> creates a new one. The second player joins the latest lobby -> black screen.
