### PR TITLE
Add Titles to assist in import to OBS

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -227,7 +227,9 @@ if (!gotTheLock) {
 	// create main BrowserWindow when electron is ready
 	app.whenReady().then(() => {
 		mainWindow = createMainWindow();
+		mainWindow.title = "CrewLink App"
 		overlayWindow = createOverlay();
+		overlayWindow.title = "CrewLink Overlay"
 		initializeIpcListeners(overlayWindow);
 		initializeIpcHandlers();
 	});


### PR DESCRIPTION
Currently, since the windows are simply titled "crewlink" (based on the executable) it's impossible to pull in the overlay for tools like OBS without doing a display capture, by titling the windows differently, OBS is able to pull them in individually (you'd have to go into a lobby for the overlay window to pop up).